### PR TITLE
fix warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.html",
   "scripts": {
-    "start": "concurrent 'npm run watch' 'http-server'",
+    "start": "concurrently 'npm run watch' 'http-server'",
     "watch": "riot -w --ext html --type es6 src/components/ dist/components.js",
     "build": "riot --ext html src/components/ dist/components.js"
   },


### PR DESCRIPTION
On a fresh install:

```
$ npm start

> my-riot-app@1.0.0 start /xxx/riotjs/myapp
> concurrent 'npm run watch' 'http-server'

Warning: "concurrent" command is deprecated, use "concurrently" instead
```

This PR fixes this error by following the advice:

> use "concurrently" instead